### PR TITLE
Add space inside hash blackets

### DIFF
--- a/lib/hash_modern_inspect.rb
+++ b/lib/hash_modern_inspect.rb
@@ -1,17 +1,17 @@
 module HashModernInspect
-  def modern_inspect
-    modern_inspect0(self)
+  def modern_inspect(options = {})
+    modern_inspect0(self, options)
   end
 
   def modern_inspect_without_brace(options = {})
     if self.empty? and not options[:allow_empty]
       self.inspect
     else
-      modern_inspect.sub(/\A\{/, '').sub(/\}\z/, '').strip
+      modern_inspect(options).sub(/\A\{/, '').sub(/\}\z/, '').strip
     end
   end
 
-  def modern_inspect0(obj)
+  def modern_inspect0(obj, options = {})
     buf = ''
 
     case obj
@@ -20,12 +20,16 @@ module HashModernInspect
 
       obj.each_with_index do |value, i|
         buf << ', ' unless i.zero?
-        buf << modern_inspect0(value)
+        buf << modern_inspect0(value, options)
       end
 
       buf << ']'
     when Hash
-      buf << '{'
+      buf << if options[:space_inside_hash]
+               '{ '
+             else
+               '{'
+             end
 
       obj.each_with_index do |kv, i|
         key, value = kv
@@ -40,13 +44,17 @@ module HashModernInspect
             buf << "#{key.to_s.inspect}: "
           end
         else
-          buf << "#{modern_inspect0(key)}=>"
+          buf << "#{modern_inspect0(key, options)}=>"
         end
 
-        buf << modern_inspect0(value)
+        buf << modern_inspect0(value, options)
       end
 
-      buf << '}'
+      buf << if options[:space_inside_hash]
+               ' }'
+             else
+               '}'
+             end
     else
       buf << obj.inspect
     end

--- a/spec/hash_modern_inspect_spec.rb
+++ b/spec/hash_modern_inspect_spec.rb
@@ -14,6 +14,11 @@ describe HashModernInspect do
 
   describe :modern_inspect do
     it { is_expected.to eq '{foo: ["FOO", {baz: 100}], bar: {zoo: 200}, "xxx-yyy": :val, "hoge"=>"piyo"}' }
+
+    context 'when space_inside_hash is true' do
+      let(:args) { [{space_inside_hash: true}] }
+      it { is_expected.to eq '{ foo: ["FOO", { baz: 100 }], bar: { zoo: 200 }, "xxx-yyy": :val, "hoge"=>"piyo" }' }
+    end
   end
 
   describe :modern_inspect_without_brace do
@@ -30,6 +35,11 @@ describe HashModernInspect do
       let(:hash) { {} }
       let(:args) { [{allow_empty: true}] }
       it { is_expected.to be_empty }
+    end
+
+    context 'when space_inside_hash is true' do
+      let(:args) { [{space_inside_hash: true}] }
+      it { is_expected.to eq 'foo: ["FOO", { baz: 100 }], bar: { zoo: 200 }, "xxx-yyy": :val, "hoge"=>"piyo"' }
     end
   end
 end


### PR DESCRIPTION
related: Ridgepole rails 6.1 roadmap.
In rails 6.1.0, the options of `create_table` is dumped like the following.

```
// input
create_table(id: { type: :bigint })

// expected output
create_table id: { type: :bigint }

// got
create_table id: {type: :bigint}
```

This behavior is implemented with `hash_modern_inspect` but current output is a little broken.

new options(`space_inside_hash: true`) supports expected result 👍 